### PR TITLE
fix(pi-fixed-editor): avoid render recursion with Pi 0.84 TUI proxy

### DIFF
--- a/.changeset/fix-fixed-editor-tui-proxy-recursion.md
+++ b/.changeset/fix-fixed-editor-tui-proxy-recursion.md
@@ -1,0 +1,5 @@
+---
+"@tifan/pi-fixed-editor": patch
+---
+
+Fix an infinite render loop on Pi 0.84+, which wraps the TUI in a re-resolving proxy. The compositor now captures the real underlying `render`, `doRender`, and `compositeLineAt` methods instead of the proxy's per-call wrappers, so the fixed editor loads and scrolls again.

--- a/packages/pi-fixed-editor/src/terminal-split.ts
+++ b/packages/pi-fixed-editor/src/terminal-split.ts
@@ -344,6 +344,36 @@ function descriptorForRows(
   return undefined
 }
 
+// Pi 0.84+ wraps the TUI in a Proxy (createInteractiveTuiReference) whose `get`
+// returns a fresh closure that re-resolves the method on every call, and whose
+// `set` writes through to the real TUI. Capturing an "original" via
+// `proxy.method.bind(proxy)` therefore yields a closure that, once we overwrite
+// the method, re-resolves back to our own replacement -> infinite recursion.
+// Resolve the real prototype method instead (the proxy exposes the real chain
+// via its getPrototypeOf trap), then bind it to the proxy as receiver so the
+// method's internal `this.*` access still flows through Pi's TUI reference.
+function resolveRealTuiMethod(
+  tui: object,
+  name: string,
+): ((...args: unknown[]) => unknown) | null {
+  // Plain object or non-proxy TUI: the method is an own property and is the
+  // real function. For Pi 0.84+'s proxy (target `{}`, no getOwnPropertyDescriptor
+  // trap) this returns undefined, so we never capture the re-resolving wrapper.
+  const own = Object.getOwnPropertyDescriptor(tui, name)
+  if (own && typeof own.value === "function") {
+    return own.value as (...args: unknown[]) => unknown
+  }
+  let proto = Object.getPrototypeOf(tui)
+  while (proto && proto !== Object.prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, name)
+    if (descriptor && typeof descriptor.value === "function") {
+      return descriptor.value as (...args: unknown[]) => unknown
+    }
+    proto = Object.getPrototypeOf(proto)
+  }
+  return null
+}
+
 function readRows(
   terminal: TerminalLike,
   descriptor: PropertyDescriptor | undefined,
@@ -521,14 +551,12 @@ export class TerminalSplitCompositor {
     this.onCopySelection = options.onCopySelection ?? null
     this.rowsDescriptor = descriptorForRows(options.terminal)
     this.originalWrite = options.terminal.write.bind(options.terminal)
-    this.originalDoRender =
-      typeof options.tui.doRender === "function"
-        ? options.tui.doRender.bind(options.tui)
-        : null
-    this.originalRender =
-      typeof options.tui.render === "function"
-        ? options.tui.render.bind(options.tui)
-        : null
+    const doRenderFn = resolveRealTuiMethod(options.tui, "doRender")
+    this.originalDoRender = doRenderFn ? doRenderFn.bind(options.tui) : null
+    const renderFn = resolveRealTuiMethod(options.tui, "render")
+    this.originalRender = renderFn
+      ? (width: number) => renderFn.call(options.tui, width) as string[]
+      : null
   }
 
   install(): void {
@@ -584,8 +612,9 @@ export class TerminalSplitCompositor {
         }
       }
     }
-    if (typeof this.tui.compositeLineAt === "function") {
-      this.originalCompositeLineAt = this.tui.compositeLineAt.bind(
+    const compositeFn = resolveRealTuiMethod(this.tui, "compositeLineAt")
+    if (compositeFn) {
+      this.originalCompositeLineAt = compositeFn.bind(
         this.tui,
       ) as CompositeLineAt
       this.tui.compositeLineAt = (

--- a/packages/pi-fixed-editor/tests/terminal-split.test.ts
+++ b/packages/pi-fixed-editor/tests/terminal-split.test.ts
@@ -569,3 +569,78 @@ test("plain enter scrolls the transcript back to the bottom", () => {
     compositor.dispose({ resetExtendedKeyboardModes: true })
   }
 })
+
+test("survives Pi 0.84 re-resolving TUI proxy without infinite recursion", () => {
+  // Mirrors createInteractiveTuiReference: `get` returns a fresh closure that
+  // re-resolves the method per call; `set` writes through to the real TUI.
+  let realDoRenders = 0
+  let realRenders = 0
+  const rootLines = ["a", "b", "c", "d", "e", "f", "g", "h"]
+
+  class FakeTui {
+    children: Component[] = []
+    doRender(): void {
+      realDoRenders += 1
+      // A real TUI resolves rendering through the same reference; going via the
+      // proxy must land on the compositor's replacement, not recurse into us.
+      ;(this as unknown as { render: (w: number) => string[] }).render(80)
+    }
+    render(_width: number): string[] {
+      realRenders += 1
+      return rootLines
+    }
+    requestRender(): void {}
+    addInputListener(): () => void {
+      return () => {}
+    }
+    hasOverlay(): boolean {
+      return false
+    }
+  }
+
+  const realTui = new FakeTui()
+  const proxy = new Proxy(
+    {},
+    {
+      get: (_t, property) => {
+        const value = Reflect.get(realTui, property, realTui)
+        if (typeof value !== "function") return value
+        return (...args: unknown[]) => {
+          const method = Reflect.get(realTui, property, realTui)
+          return Reflect.apply(
+            method as (...a: unknown[]) => unknown,
+            realTui,
+            args,
+          )
+        }
+      },
+      set: (_t, property, value) =>
+        Reflect.set(realTui, property, value, realTui),
+      has: (_t, property) => Reflect.has(realTui, property),
+      getPrototypeOf: () => Reflect.getPrototypeOf(realTui),
+    },
+  )
+
+  const terminal: TerminalLike = { columns: 80, rows: 6, write: () => {} }
+  const compositor = new TerminalSplitCompositor({
+    tui: proxy as unknown as ConstructorParameters<
+      typeof TerminalSplitCompositor
+    >[0]["tui"],
+    terminal,
+    renderCluster: () => ({ lines: ["editor", "footer"], cursor: null }),
+  })
+
+  compositor.install()
+  try {
+    // Drive doRender through the proxy the way Pi does. Pre-fix this recursed
+    // forever (RangeError: Maximum call stack size exceeded).
+    ;(proxy as unknown as { doRender: () => void }).doRender()
+    ;(proxy as unknown as { doRender: () => void }).doRender()
+
+    // The real prototype methods must have run exactly as invoked (no runaway).
+    assert.equal(realDoRenders, 2)
+    assert.ok(realRenders > 0)
+  } finally {
+    compositor.dispose({ resetExtendedKeyboardModes: true })
+  }
+})


### PR DESCRIPTION
Pi 0.84 wraps the TUI in createInteractiveTuiReference, a Proxy whose get returns a closure that re-resolves the method per call and whose set writes through to the real TUI. Capturing originals via proxy.method.bind(proxy) meant the saved original re-resolved back to the compositor's own replacement after patching, causing infinite recursion in doRender/render.

Resolve the real underlying methods (own property, else prototype chain) and bind them to the proxy as receiver.