### PR TITLE
feat(rename): support localized session names

### DIFF
--- a/.changeset/localized-session-names.md
+++ b/.changeset/localized-session-names.md
@@ -1,0 +1,5 @@
+---
+"@tifan/pi-rename": minor
+---
+
+Add language configuration for generated session names with BCP 47 tags and automatic language detection.

--- a/packages/pi-rename/README.md
+++ b/packages/pi-rename/README.md
@@ -25,6 +25,7 @@ If the rename model is unavailable, `/rename` falls back to a local name from th
 - `/rename`: Generate and apply a session name.
 - `/rename status`: Show model and rename status.
 - `/rename config`: Choose a rename model.
+- `/rename config language <auto|BCP-47>`: Set session-name language.
 - `/rename help`: List rename commands.
 
 Manual names are not supported. Use pi's built-in `/name` command when you want an exact name.
@@ -37,13 +38,26 @@ Run `/rename config` to choose a different model.
 
 After you choose a model, `pi-rename` uses only that model. Choose `Use default` in `/rename config` to return to the default.
 
+Session names default to English ASCII. Set another output language with a BCP 47 tag, or use `auto` to follow latest user message language:
+
+```bash
+/rename config language zh
+/rename config language ja
+/rename config language auto
+```
+
+Non-English and `auto` names preserve Unicode letters and numbers. If rename model is unavailable, fallback uses latest user message and does not translate it.
+
 You can also edit `$PI_CODING_AGENT_DIR/extensions/pi-rename.json` manually:
 
 ```json
 {
-  "model": "openai-codex/gpt-5.6-luna"
+  "model": "openai-codex/gpt-5.6-luna",
+  "language": "zh"
 }
 ```
+
+Use `"language": "en"` for default ASCII behavior. Missing or invalid language values also fall back to `en`.
 
 ## Herdr behavior
 

--- a/packages/pi-rename/README.md
+++ b/packages/pi-rename/README.md
@@ -38,26 +38,25 @@ Run `/rename config` to choose a different model.
 
 After you choose a model, `pi-rename` uses only that model. Choose `Use default` in `/rename config` to return to the default.
 
-Session names default to English ASCII. Set another output language with a BCP 47 tag, or use `auto` to follow latest user message language:
+To preserve existing behavior, names use ASCII when no language is configured. Set an output language with a BCP 47 tag, or use `auto` to follow latest user message language:
 
 ```bash
-/rename config language zh
-/rename config language ja
+/rename config language <BCP-47-tag>
 /rename config language auto
 ```
 
-Non-English and `auto` names preserve Unicode letters and numbers. If rename model is unavailable, fallback uses latest user message and does not translate it.
+`auto` and non-`en` tags preserve Unicode letters and numbers. If rename model is unavailable, fallback uses latest user message and does not translate it.
 
 You can also edit `$PI_CODING_AGENT_DIR/extensions/pi-rename.json` manually:
 
 ```json
 {
   "model": "openai-codex/gpt-5.6-luna",
-  "language": "zh"
+  "language": "auto"
 }
 ```
 
-Use `"language": "en"` for default ASCII behavior. Missing or invalid language values also fall back to `en`.
+Use `"language": "en"` for ASCII compatibility mode. Missing or invalid language values also fall back to `en`.
 
 ## Herdr behavior
 

--- a/packages/pi-rename/src/index.ts
+++ b/packages/pi-rename/src/index.ts
@@ -304,24 +304,9 @@ function getRenameArgumentCompletions(
   prefix: string,
 ): AutocompleteItem[] | null {
   const query = prefix.trimStart().toLowerCase()
-  const items = [
-    ...RENAME_SUBCOMMANDS,
-    {
-      value: "config language auto",
-      label: "config language auto",
-      description: "Use latest user message language",
-    },
-    {
-      value: "config language en",
-      label: "config language en",
-      description: "Use English ASCII names",
-    },
-    {
-      value: "config language zh",
-      label: "config language zh",
-      description: "Use Chinese names",
-    },
-  ].filter((item) => item.value.startsWith(query))
+  const items = RENAME_SUBCOMMANDS.filter((item) =>
+    item.value.startsWith(query),
+  )
   return items.length > 0 ? items : null
 }
 

--- a/packages/pi-rename/src/index.ts
+++ b/packages/pi-rename/src/index.ts
@@ -12,14 +12,20 @@ import type {
 import { buildSessionContext } from "@earendil-works/pi-coding-agent"
 import { pickRenameModel } from "./model-picker.js"
 import {
-  deleteRenameConfig,
+  DEFAULT_RENAME_LANGUAGE,
+  parseRenameLanguage,
+  type RenameLanguage,
+} from "./language.js"
+import {
+  deleteModelPreference,
   formatAuthModelKey,
   formatModelPreference,
   formatRenameModelKey,
   getAuthenticatedTextModelPreferences,
   getRenameModelAuth,
-  resolveInitialModelConfig,
+  resolveInitialRenameConfig,
   saveModelPreference,
+  saveRenameLanguage,
   type RenameModelConfig,
 } from "./models.js"
 import { isTemporaryHerdrLabel } from "./herdr-label.js"
@@ -32,6 +38,7 @@ interface SessionContextReader {
 
 interface RenameState {
   modelConfig: RenameModelConfig
+  language: RenameLanguage
 }
 
 const RENAME_SUBCOMMANDS: AutocompleteItem[] = [
@@ -55,6 +62,7 @@ const RENAME_SUBCOMMANDS: AutocompleteItem[] = [
 function createRenameState(): RenameState {
   return {
     modelConfig: { kind: "missing" },
+    language: DEFAULT_RENAME_LANGUAGE,
   }
 }
 
@@ -241,7 +249,12 @@ async function runRenameCommand(
     })
   }
   try {
-    const result = await generateRename(ctx, state.modelConfig, context)
+    const result = await generateRename(
+      ctx,
+      state.modelConfig,
+      context,
+      state.language,
+    )
     if (!result) {
       ctx.ui.notify("Could not generate a session name.", "error")
       return
@@ -291,9 +304,24 @@ function getRenameArgumentCompletions(
   prefix: string,
 ): AutocompleteItem[] | null {
   const query = prefix.trimStart().toLowerCase()
-  const items = RENAME_SUBCOMMANDS.filter((item) =>
-    item.value.startsWith(query),
-  )
+  const items = [
+    ...RENAME_SUBCOMMANDS,
+    {
+      value: "config language auto",
+      label: "config language auto",
+      description: "Use latest user message language",
+    },
+    {
+      value: "config language en",
+      label: "config language en",
+      description: "Use English ASCII names",
+    },
+    {
+      value: "config language zh",
+      label: "config language zh",
+      description: "Use Chinese names",
+    },
+  ].filter((item) => item.value.startsWith(query))
   return items.length > 0 ? items : null
 }
 
@@ -315,7 +343,7 @@ async function configureRenameModel(
 
   try {
     if (result.action === "default") {
-      deleteRenameConfig()
+      deleteModelPreference()
       state.modelConfig = { kind: "missing" }
       ctx.ui.notify("Rename model reset to default.", "info")
       return
@@ -327,6 +355,28 @@ async function configureRenameModel(
       `Rename model set to ${formatRenameModelKey(result.model)}.`,
       "info",
     )
+  } catch (error) {
+    const reason =
+      error instanceof SyntaxError ? "invalid JSON" : "write failed"
+    ctx.ui.notify(`Could not update rename config: ${reason}.`, "error")
+  }
+}
+
+function configureRenameLanguage(
+  ctx: ExtensionContext,
+  state: RenameState,
+  value: string | undefined,
+): void {
+  const language = parseRenameLanguage(value)
+  if (!language) {
+    ctx.ui.notify("Use /rename config language <auto|BCP-47>", "error")
+    return
+  }
+
+  try {
+    saveRenameLanguage(language)
+    state.language = language
+    ctx.ui.notify(`Rename language set to ${language}.`, "info")
   } catch (error) {
     const reason =
       error instanceof SyntaxError ? "invalid JSON" : "write failed"
@@ -365,6 +415,7 @@ async function notifyRenameStatus(
       "pi-rename status",
       selectedModelLine,
       activeModelLine,
+      `language: ${state.language}`,
       herdrLine,
       contextLine,
     ].join("\n"),
@@ -377,20 +428,22 @@ function registerRenameCommand(pi: ExtensionAPI, state: RenameState): void {
     description: "generate a session name",
     getArgumentCompletions: getRenameArgumentCompletions,
     handler: async (args, ctx) => {
-      const action = args.trim().split(/\s+/u)[0]?.toLowerCase() ?? ""
+      const [action = "", ...actionArgs] = args.trim().split(/\s+/u)
+      const normalizedAction = action.toLowerCase()
 
-      if (!action) {
+      if (!normalizedAction) {
         await runRenameCommand(pi, ctx, state)
         return
       }
 
-      if (action === "help") {
+      if (normalizedAction === "help") {
         ctx.ui.notify(
           [
             "pi-rename commands",
             "/rename - generate and apply a session name",
             "/rename status - show model and rename status",
             "/rename config - choose the rename model",
+            "/rename config language <auto|BCP-47> - set name language",
             "/rename help - show this help",
           ].join("\n"),
           "info",
@@ -398,13 +451,24 @@ function registerRenameCommand(pi: ExtensionAPI, state: RenameState): void {
         return
       }
 
-      if (action === "status") {
+      if (normalizedAction === "status") {
         await notifyRenameStatus(ctx, state)
         return
       }
 
-      if (action === "config") {
-        await configureRenameModel(ctx, state)
+      if (normalizedAction === "config") {
+        const [setting, value, extra] = actionArgs
+        if (!setting) {
+          await configureRenameModel(ctx, state)
+          return
+        }
+
+        if (setting.toLowerCase() === "language" && !extra) {
+          configureRenameLanguage(ctx, state, value)
+          return
+        }
+
+        ctx.ui.notify("Use /rename config language <auto|BCP-47>", "error")
         return
       }
 
@@ -419,7 +483,9 @@ export default function (pi: ExtensionAPI): void {
   registerRenameCommand(pi, state)
 
   pi.on("session_start", async () => {
-    state.modelConfig = resolveInitialModelConfig()
+    const initialConfig = resolveInitialRenameConfig()
+    state.modelConfig = initialConfig.modelConfig
+    state.language = initialConfig.language
 
     const sessionName = pi.getSessionName()?.trim()
     if (!sessionName) return

--- a/packages/pi-rename/src/language.ts
+++ b/packages/pi-rename/src/language.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_RENAME_LANGUAGE = "en"
+export type RenameLanguage = string
+
+export function parseRenameLanguage(
+  value: unknown,
+): RenameLanguage | undefined {
+  if (typeof value !== "string") return undefined
+
+  const trimmed = value.trim()
+  if (trimmed.toLowerCase() === "auto") return "auto"
+  if (!trimmed) return undefined
+
+  try {
+    return Intl.getCanonicalLocales(trimmed)[0]
+  } catch {
+    return undefined
+  }
+}

--- a/packages/pi-rename/src/models.ts
+++ b/packages/pi-rename/src/models.ts
@@ -11,6 +11,11 @@ import {
   getAgentDir,
   type ExtensionContext,
 } from "@earendil-works/pi-coding-agent"
+import {
+  DEFAULT_RENAME_LANGUAGE,
+  parseRenameLanguage,
+  type RenameLanguage,
+} from "./language.js"
 
 const CONFIG_PATH = path.join(getAgentDir(), "extensions", "pi-rename.json")
 const CONFIG_DIR = path.dirname(CONFIG_PATH)
@@ -49,6 +54,12 @@ export const DEFAULT_RENAME_MODEL: RenameModelPreference = {
 
 interface RenameConfig extends Record<string, unknown> {
   model?: unknown
+  language?: unknown
+}
+
+export interface InitialRenameConfig {
+  readonly modelConfig: RenameModelConfig
+  readonly language: RenameLanguage
 }
 
 export function formatModelPreference(config: RenameModelConfig): string {
@@ -89,32 +100,71 @@ function readConfig(): RenameConfig {
     : {}
 }
 
-export function saveModelPreference(
-  modelPreference: RenameModelPreference,
-): void {
-  const config: RenameConfig = {
-    model: formatRenameModelKey(modelPreference),
-  }
+function writeConfig(config: RenameConfig): void {
   mkdirSync(CONFIG_DIR, { recursive: true })
   writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`, "utf-8")
 }
 
-export function deleteRenameConfig(): void {
-  rmSync(CONFIG_PATH, { force: true })
+function updateConfig(update: Partial<RenameConfig>): void {
+  const config = existsSync(CONFIG_PATH) ? readConfig() : {}
+  writeConfig({ ...config, ...update })
 }
 
-export function resolveInitialModelConfig(): RenameModelConfig {
-  if (!existsSync(CONFIG_PATH)) return { kind: "missing" }
+export function saveModelPreference(
+  modelPreference: RenameModelPreference,
+): void {
+  updateConfig({ model: formatRenameModelKey(modelPreference) })
+}
+
+export function saveRenameLanguage(language: RenameLanguage): void {
+  updateConfig({ language })
+}
+
+export function deleteModelPreference(): void {
+  if (!existsSync(CONFIG_PATH)) return
+
+  const config = readConfig()
+  delete config.model
+  if (Object.keys(config).length === 0) {
+    rmSync(CONFIG_PATH)
+    return
+  }
+
+  writeConfig(config)
+}
+
+function resolveModelConfig(config: RenameConfig): RenameModelConfig {
+  if (config.model === undefined) return { kind: "missing" }
+  if (typeof config.model !== "string") return { kind: "invalid" }
+
+  const model = parseModelSpec(config.model)
+  return model ? { kind: "configured", model } : { kind: "invalid" }
+}
+
+export function resolveInitialRenameConfig(): InitialRenameConfig {
+  if (!existsSync(CONFIG_PATH)) {
+    return {
+      modelConfig: { kind: "missing" },
+      language: DEFAULT_RENAME_LANGUAGE,
+    }
+  }
 
   try {
     const config = readConfig()
-    if (typeof config.model !== "string") return { kind: "invalid" }
-
-    const model = parseModelSpec(config.model)
-    return model ? { kind: "configured", model } : { kind: "invalid" }
+    return {
+      modelConfig: resolveModelConfig(config),
+      language: parseRenameLanguage(config.language) ?? DEFAULT_RENAME_LANGUAGE,
+    }
   } catch {
-    return { kind: "invalid" }
+    return {
+      modelConfig: { kind: "invalid" },
+      language: DEFAULT_RENAME_LANGUAGE,
+    }
   }
+}
+
+export function resolveInitialModelConfig(): RenameModelConfig {
+  return resolveInitialRenameConfig().modelConfig
 }
 
 async function getModelAuth(

--- a/packages/pi-rename/src/models.ts
+++ b/packages/pi-rename/src/models.ts
@@ -105,9 +105,19 @@ function writeConfig(config: RenameConfig): void {
   writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`, "utf-8")
 }
 
+function readConfigForUpdate(): RenameConfig {
+  if (!existsSync(CONFIG_PATH)) return {}
+
+  try {
+    return readConfig()
+  } catch (error) {
+    if (error instanceof SyntaxError) return {}
+    throw error
+  }
+}
+
 function updateConfig(update: Partial<RenameConfig>): void {
-  const config = existsSync(CONFIG_PATH) ? readConfig() : {}
-  writeConfig({ ...config, ...update })
+  writeConfig({ ...readConfigForUpdate(), ...update })
 }
 
 export function saveModelPreference(
@@ -123,7 +133,7 @@ export function saveRenameLanguage(language: RenameLanguage): void {
 export function deleteModelPreference(): void {
   if (!existsSync(CONFIG_PATH)) return
 
-  const config = readConfig()
+  const config = readConfigForUpdate()
   delete config.model
   if (Object.keys(config).length === 0) {
     rmSync(CONFIG_PATH)
@@ -161,10 +171,6 @@ export function resolveInitialRenameConfig(): InitialRenameConfig {
       language: DEFAULT_RENAME_LANGUAGE,
     }
   }
-}
-
-export function resolveInitialModelConfig(): RenameModelConfig {
-  return resolveInitialRenameConfig().modelConfig
 }
 
 async function getModelAuth(

--- a/packages/pi-rename/src/naming.ts
+++ b/packages/pi-rename/src/naming.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core"
 import type { Message } from "@earendil-works/pi-ai"
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent"
+import type { RenameLanguage } from "./language.js"
 import {
   formatRenameModelKey,
   getRenameModelAuth,
@@ -17,6 +18,24 @@ Return one lowercase hyphen-separated session name only.
 Use plain text, no quotes, no markdown, no trailing punctuation.
 Prefer an action-oriented task name like fix-auth-callback or design-pi-rename.
 Stay under 60 characters.`
+
+export function buildRenameSystemPrompt(language: RenameLanguage): string {
+  if (/^en(?:-|$)/iu.test(language)) return RENAME_SYSTEM_PROMPT
+
+  const languageInstruction =
+    language === "auto"
+      ? "Use language of latest user message."
+      : `Use language identified by BCP 47 tag ${language}.`
+
+  return `Name this coding-agent session.
+
+${languageInstruction}
+Return one hyphen-separated session name only.
+Use plain text, no quotes, no markdown, no trailing punctuation.
+Use lowercase when selected language has case.
+Prefer an action-oriented task name.
+Stay under 60 characters.`
+}
 
 export interface UserMessageContext {
   readonly first: string
@@ -109,15 +128,17 @@ function extractModelText(
 
 export function fallbackRenameName(
   context: UserMessageContext,
+  language: RenameLanguage = "en",
 ): string | undefined {
   const latest = context.recent.at(-1) ?? context.first
-  return sanitizeRenameText(latest)
+  return sanitizeRenameText(latest, language)
 }
 
 export async function generateRename(
   ctx: ExtensionContext,
   modelConfig: RenameModelConfig,
   context: UserMessageContext,
+  language: RenameLanguage = "en",
 ): Promise<RenameResult | undefined> {
   try {
     const modelAuth = await getRenameModelAuth(ctx, modelConfig)
@@ -126,7 +147,7 @@ export async function generateRename(
       const response = await ctx.modelRegistry.complete(
         modelAuth.auth.model,
         {
-          systemPrompt: RENAME_SYSTEM_PROMPT,
+          systemPrompt: buildRenameSystemPrompt(language),
           messages: [buildRenamePrompt(context)],
         },
         {
@@ -138,11 +159,14 @@ export async function generateRename(
       )
 
       if (response.stopReason === "stop") {
-        const name = sanitizeRenameText(extractModelText(response.content))
+        const name = sanitizeRenameText(
+          extractModelText(response.content),
+          language,
+        )
         if (name) return { source: "model", name }
       }
 
-      const name = fallbackRenameName(context)
+      const name = fallbackRenameName(context, language)
       return name
         ? {
             source: "fallback",
@@ -152,7 +176,7 @@ export async function generateRename(
         : undefined
     }
 
-    const name = fallbackRenameName(context)
+    const name = fallbackRenameName(context, language)
     if (!name) return undefined
 
     if (modelAuth.status === "invalid-config") {
@@ -172,7 +196,7 @@ export async function generateRename(
       reason: `rename model is not authenticated: ${modelName}`,
     }
   } catch (error) {
-    const name = fallbackRenameName(context)
+    const name = fallbackRenameName(context, language)
     if (!name) return undefined
     const reason = error instanceof Error ? error.message : String(error)
     return { source: "fallback", name, reason }

--- a/packages/pi-rename/src/naming.ts
+++ b/packages/pi-rename/src/naming.ts
@@ -16,7 +16,7 @@ export const RENAME_SYSTEM_PROMPT = `Name this coding-agent session.
 
 Return one lowercase hyphen-separated session name only.
 Use plain text, no quotes, no markdown, no trailing punctuation.
-Prefer an action-oriented task name like fix-auth-callback or design-pi-rename.
+Prefer an action-oriented task name.
 Stay under 60 characters.`
 
 export function buildRenameSystemPrompt(language: RenameLanguage): string {

--- a/packages/pi-rename/src/sanitize.ts
+++ b/packages/pi-rename/src/sanitize.ts
@@ -15,19 +15,27 @@ export function redactSecrets(text: string): string {
     )
 }
 
-export function sanitizeRenameText(raw: string): string {
-  return raw
-    .trim()
-    .replace(/^```(?:\w+)?/u, "")
-    .replace(/```$/u, "")
-    .replace(/^name\s*:\s*/iu, "")
-    .replace(/^title\s*:\s*/iu, "")
-    .replace(/^[-*•]\s*/u, "")
-    .replace(/["'`]/gu, "")
-    .replace(/[^a-z0-9]+/giu, "-")
-    .replace(/-+/gu, "-")
-    .replace(/^-|-$/gu, "")
-    .toLowerCase()
+export function sanitizeRenameText(raw: string, language = "en"): string {
+  const allowUnicode = !/^en(?:-|$)/iu.test(language)
+  const disallowedCharacters = allowUnicode
+    ? /[^\p{L}\p{M}\p{N}]+/gu
+    : /[^a-z0-9]+/giu
+
+  return Array.from(
+    raw
+      .trim()
+      .replace(/^```(?:\w+)?/u, "")
+      .replace(/```$/u, "")
+      .replace(/^name\s*:\s*/iu, "")
+      .replace(/^title\s*:\s*/iu, "")
+      .replace(/^[-*•]\s*/u, "")
+      .replace(/["'`]/gu, "")
+      .replace(disallowedCharacters, "-")
+      .replace(/-+/gu, "-")
+      .replace(/^-|-$/gu, "")
+      .toLowerCase(),
+  )
     .slice(0, MAX_RENAME_CHARS)
+    .join("")
     .replace(/-$/u, "")
 }

--- a/packages/pi-rename/tests/language.test.ts
+++ b/packages/pi-rename/tests/language.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { parseRenameLanguage } from "../src/language.ts"
+import { sanitizeRenameText } from "../src/sanitize.ts"
+
+test("accepts auto and canonical BCP 47 language tags", () => {
+  assert.equal(parseRenameLanguage("auto"), "auto")
+  assert.equal(parseRenameLanguage("zh-cn"), "zh-CN")
+  assert.equal(parseRenameLanguage("ja"), "ja")
+  assert.equal(parseRenameLanguage("not a language"), undefined)
+})
+
+test("keeps existing ASCII names for English", () => {
+  assert.equal(sanitizeRenameText("Fix 登录 callback!", "en"), "fix-callback")
+  assert.equal(sanitizeRenameText("修复登录回调", "en"), "")
+})
+
+test("preserves Unicode names for selected and automatic languages", () => {
+  assert.equal(
+    sanitizeRenameText("修复 登录 callback!", "zh"),
+    "修复-登录-callback",
+  )
+  assert.equal(
+    sanitizeRenameText("認証コールバックを修正", "auto"),
+    "認証コールバックを修正",
+  )
+  assert.equal(
+    sanitizeRenameText("Ajouter l’authentification", "fr"),
+    "ajouter-l-authentification",
+  )
+})
+
+test("truncates Unicode text without splitting code points", () => {
+  const input = "𐐀".repeat(61)
+  assert.equal(sanitizeRenameText(input, "auto"), "𐐨".repeat(60))
+})

--- a/packages/pi-rename/tests/models.test.ts
+++ b/packages/pi-rename/tests/models.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { after, test } from "node:test"
+
+const originalAgentDir = process.env["PI_CODING_AGENT_DIR"]
+const agentDir = mkdtempSync(path.join(tmpdir(), "pi-rename-models-"))
+process.env["PI_CODING_AGENT_DIR"] = agentDir
+
+const { deleteModelPreference, saveModelPreference } =
+  await import("../src/models.ts")
+
+after(() => {
+  if (originalAgentDir === undefined) {
+    delete process.env["PI_CODING_AGENT_DIR"]
+  } else {
+    process.env["PI_CODING_AGENT_DIR"] = originalAgentDir
+  }
+  rmSync(agentDir, { recursive: true, force: true })
+})
+
+test("recovers from malformed config when saving and resetting", () => {
+  const configPath = path.join(agentDir, "extensions", "pi-rename.json")
+  mkdirSync(path.dirname(configPath), { recursive: true })
+  writeFileSync(configPath, "{", "utf8")
+
+  assert.doesNotThrow(() =>
+    saveModelPreference({ provider: "test-provider", id: "test-model" }),
+  )
+  assert.deepEqual(JSON.parse(readFileSync(configPath, "utf8")), {
+    model: "test-provider/test-model",
+  })
+
+  writeFileSync(configPath, "{", "utf8")
+  assert.doesNotThrow(deleteModelPreference)
+  assert.equal(existsSync(configPath), false)
+})


### PR DESCRIPTION
Adds BCP 47 language configuration for session-name generation.

Keeps existing ASCII behavior by default and preserves Unicode names for other languages or `auto`.